### PR TITLE
Fix return type of `Locale.filterTags`

### DIFF
--- a/.changeset/yellow-jokes-love.md
+++ b/.changeset/yellow-jokes-love.md
@@ -1,0 +1,5 @@
+---
+"@item-enonic-types/lib-time": patch
+---
+
+Fix return type of `Locale.filterTags` from `Locale` to the correct `string`.

--- a/README.md
+++ b/README.md
@@ -107,11 +107,32 @@ const time = today.format(formatter);
 // time = "tirsdag 21. februar 2023 12:15:30"
 ```
 
+*Example of using hte `LanguageRange` utility to find the preferred locale among the ones supported by the application.*
+
+```typescript
+import { LanguageRange, Locale } from "/lib/time";
+import { getSupportedLocales } from "/lib/xp/i18n";
+import type { Request, Response } from "@enonic-types/core";
+
+export function get(req: Request): Response {
+  const languageRange = LanguageRange.parse(req.headers["Accept-Language"]);
+  
+  const locale: string = Locale.filterTags(
+    languageRange, 
+    getSupportedLocales(["i18n/phrases"])
+  )[0];
+  
+  ...
+}
+
+```
+
 ### Constants exposed from `"/lib/time"`
 The following classes is exposed/exported from `"/lib/time"`:
 * `DateTimeFormatter`
 * `DayOfWeek`
 * `Instant`
+* `LanguageRange`
 * `LocalDate`
 * `LocalDateTime`
 * `Locale`

--- a/src/main/resources/lib/time/util.ts
+++ b/src/main/resources/lib/time/util.ts
@@ -34,7 +34,7 @@ export interface LocaleConstructor {
   UNICODE_LOCALE_EXTENSION: Locale;
   US: Locale;
   filter(priorityList: LanguageRange[], locales: Locale[]): Locale[];
-  filterTags(priorityList: LanguageRange[], tags: string[]): Locale[];
+  filterTags(priorityList: LanguageRange[], tags: string[]): string[];
   forLanguageTag(languageTag: string): Locale;
   getAvailableLocales(): Locale[];
   getDefault(): Locale;


### PR DESCRIPTION
It was incorrectly set as `Locale` when it should be `string`.